### PR TITLE
Fix: Prevent Tauri API errors and clarify dev command usage

### DIFF
--- a/frontend/src/store/appStore.ts
+++ b/frontend/src/store/appStore.ts
@@ -94,109 +94,279 @@ export const useAppStore = create<AppState>((set, get) => ({
   // Data actions
   loadDailyNote: async (date: string) => {
     set({ isLoading: true, error: undefined });
-    try {
-      const blocks: Block[] = await invoke('get_daily_note', { date });
-      const currentPage = blocks.find(block => block.is_page);
+    // @ts-expect-error __TAURI__ is injected by Tauri
+    if (window.__TAURI__) {
+      try {
+        const blocks: Block[] = await invoke('get_daily_note', { date });
+        const currentPage = blocks.find(block => block.is_page);
+        set({
+          blocks,
+          currentPage,
+          isLoading: false
+        });
+      } catch (error) {
+        console.error("Error invoking get_daily_note:", error);
+        set({
+          error: error as string,
+          isLoading: false
+        });
+      }
+    } else {
+      console.warn('Tauri API (window.__TAURI__) not found. Skipping loadDailyNote.');
       set({ 
-        blocks, 
-        currentPage,
-        isLoading: false 
-      });
-    } catch (error) {
-      set({ 
-        error: error as string, 
-        isLoading: false 
+        isLoading: false,
+        blocks: [],
+        currentPage: undefined,
       });
     }
   },
 
   loadPage: async (title: string) => {
     set({ isLoading: true, error: undefined });
-    try {
-      const page: Block | null = await invoke('get_page_by_title', { title });
-      if (page) {
-        const children: Block[] = await invoke('get_block_children', { parentId: page.id });
-        const blocks = [page, ...children];
+    // @ts-expect-error __TAURI__ is injected by Tauri
+    if (window.__TAURI__) {
+      try {
+        const page: Block | null = await invoke('get_page_by_title', { title });
+        if (page) {
+          const children: Block[] = await invoke('get_block_children', { parentId: page.id });
+          const blocks = [page, ...children];
+          set({
+            blocks,
+            currentPage: page,
+            isLoading: false
+          });
+        } else {
+          // Create new page
+          // Ensure createBlock itself is guarded or this will fail if __TAURI__ is not present
+          const newPage = await get().createBlock({
+            content: undefined,
+            parent_id: undefined,
+            order: 0,
+            is_page: true,
+            page_title: title,
+          });
+          // If createBlock did nothing due to lack of Tauri, newPage might be undefined or represent an error.
+          // This needs careful handling based on createBlock's guarded implementation.
+          if (newPage) { // Assuming createBlock returns something meaningful or null/undefined
+            set({
+              blocks: [newPage],
+              currentPage: newPage,
+              isLoading: false
+            });
+          } else {
+            // If newPage couldn't be created (e.g., Tauri not available), set appropriate state
+            set({
+              blocks: [],
+              currentPage: undefined,
+              isLoading: false,
+              error: "Failed to create page: Tauri API not available."
+            });
+          }
+        }
+      } catch (error) {
+        console.error("Error invoking get_page_by_title or get_block_children:", error);
         set({ 
-          blocks, 
-          currentPage: page,
-          isLoading: false 
-        });
-      } else {
-        // Create new page
-        const newPage = await get().createBlock({
-          content: undefined,
-          parent_id: undefined,
-          order: 0,
-          is_page: true,
-          page_title: title,
-        });
-        set({ 
-          blocks: [newPage], 
-          currentPage: newPage,
+          error: error as string,
           isLoading: false 
         });
       }
-    } catch (error) {
+    } else {
+      console.warn('Tauri API (window.__TAURI__) not found. Skipping loadPage.');
       set({ 
-        error: error as string, 
-        isLoading: false 
+        isLoading: false,
+        blocks: [],
+        currentPage: undefined,
       });
     }
   },
 
   createBlock: async (blockData: CreateBlockRequest, audioMeta?: AudioMeta) => {
-    try {
-      const newBlock: Block = await invoke('create_block', { blockData, audioMeta });
-      
-      set(state => ({
-        blocks: [...state.blocks, newBlock]
-      }));
-      
-      return newBlock;
-    } catch (error) {
-      set({ error: error as string });
-      throw error;
+    // @ts-expect-error __TAURI__ is injected by Tauri
+    if (window.__TAURI__) {
+      try {
+        const newBlock: Block = await invoke('create_block', { blockData, audioMeta });
+
+        set(state => ({
+          blocks: [...state.blocks, newBlock]
+        }));
+
+        return newBlock;
+      } catch (error) {
+        console.error("Error invoking create_block:", error);
+        set({ error: error as string });
+        throw error; // Re-throw or handle as per desired UX
+      }
+    } else {
+      console.warn('Tauri API (window.__TAURI__) not found. Skipping createBlock.');
+      // Decide what to return or how to signal failure.
+      // Throwing an error might be appropriate if the caller expects a Block.
+      // Or return a specific value like null or undefined and let caller handle.
+      // For now, logging and throwing an error.
+      set({ error: "Tauri API not available" });
+      throw new Error("Tauri API not available, cannot create block.");
     }
   },
 
   updateBlockContent: async (blockId: string, content: string) => {
-    try {
-      await invoke('update_block_content', { blockId, content });
-      
-      set(state => ({
-        blocks: state.blocks.map(block => 
-          block.id === blockId 
-            ? { ...block, content, updated_at: new Date().toISOString() }
-            : block
-        )
-      }));
-    } catch (error) {
-      set({ error: error as string });
-      throw error;
+    // @ts-expect-error __TAURI__ is injected by Tauri
+    if (window.__TAURI__) {
+      try {
+        await invoke('update_block_content', { blockId, content });
+
+        set(state => ({
+          blocks: state.blocks.map(block =>
+            block.id === blockId
+              ? { ...block, content, updated_at: new Date().toISOString() }
+              : block
+          )
+        }));
+      } catch (error) {
+        console.error("Error invoking update_block_content:", error);
+        set({ error: error as string });
+        throw error; // Re-throw or handle
+      }
+    } else {
+      console.warn('Tauri API (window.__TAURI__) not found. Skipping updateBlockContent.');
+      set({ error: "Tauri API not available" });
+      // Potentially throw an error or manage state to indicate failure
     }
   },
 
   deleteBlock: async (blockId: string) => {
-    try {
-      await invoke('delete_block', { blockId });
-      
-      set(state => ({
-        blocks: state.blocks.filter(block => block.id !== blockId)
-      }));
-    } catch (error) {
-      set({ error: error as string });
-      throw error;
+    // @ts-expect-error __TAURI__ is injected by Tauri
+    if (window.__TAURI__) {
+      try {
+        await invoke('delete_block', { blockId });
+
+        set(state => ({
+          blocks: state.blocks.filter(block => block.id !== blockId)
+        }));
+      } catch (error) {
+        console.error("Error invoking delete_block:", error);
+        set({ error: error as string });
+        throw error; // Re-throw or handle
+      }
+    } else {
+      console.warn('Tauri API (window.__TAURI__) not found. Skipping deleteBlock.');
+      set({ error: "Tauri API not available" });
+      // Potentially throw an error or manage state to indicate failure
     }
   },
 
   // Audio actions
   startRecording: async (pageId: string) => {
-    try {
-      const recordingId: string = await invoke('start_recording', { pageId });
-      
+    // @ts-expect-error __TAURI__ is injected by Tauri
+    if (window.__TAURI__) {
+      try {
+        const recordingId: string = await invoke('start_recording', { pageId });
+
+        set(state => ({
+          audioState: {
+            ...state.audioState,
+            isRecording: true,
+            recordingId,
+            pageId,
+            startTime: Date.now(),
+          }
+        }));
+      } catch (error) {
+        console.error("Error invoking start_recording:", error);
+        set({ error: error as string });
+        throw error; // Re-throw or handle
+      }
+    } else {
+      console.warn('Tauri API (window.__TAURI__) not found. Skipping startRecording.');
       set(state => ({
         audioState: {
+          ...state.audioState,
+          isRecording: false, // Ensure recording state is not stuck
+        },
+        error: "Tauri API not available",
+      }));
+      // Do not throw error here to match original behavior of not throwing for UI updates
+    }
+  },
+
+  stopRecording: async () => {
+    const { audioState } = get();
+    if (!audioState.recordingId) return;
+
+    // @ts-expect-error __TAURI__ is injected by Tauri
+    if (window.__TAURI__) {
+      try {
+        await invoke('stop_recording', { recordingId: audioState.recordingId });
+
+        set(state => ({
+          audioState: {
+            ...state.audioState,
+            isRecording: false,
+            recordingId: undefined,
+            pageId: undefined,
+            startTime: undefined,
+          }
+        }));
+      } catch (error) {
+        console.error("Error invoking stop_recording:", error);
+        set({ error: error as string });
+        throw error; // Re-throw or handle
+      }
+    } else {
+      console.warn('Tauri API (window.__TAURI__) not found. Skipping stopRecording.');
+      set(state => ({
+        audioState: {
+          ...state.audioState,
+          isRecording: false, // Ensure recording state is reset
+          recordingId: undefined,
+          pageId: undefined,
+          startTime: undefined,
+        },
+        error: "Tauri API not available",
+      }));
+      // Do not throw error here to match original behavior of not throwing for UI updates
+    }
+  },
+
+  loadAudioDevices: async () => {
+    // @ts-expect-error __TAURI__ is injected by Tauri
+    if (window.__TAURI__) {
+      try {
+        const devices: AudioDevice[] = await invoke('get_audio_devices');
+
+        set(state => ({
+          audioState: {
+            ...state.audioState,
+            devices,
+          }
+        }));
+      } catch (error) {
+        console.error("Error invoking get_audio_devices:", error);
+        set({ error: error as string });
+        // Potentially re-throw or handle more gracefully depending on desired UX
+        // For now, just setting the error state
+      }
+    } else {
+      console.warn('Tauri API (window.__TAURI__) not found. Skipping loadAudioDevices.');
+      // Optionally set devices to empty array or a default state
+      set(state => ({
+        audioState: {
+          ...state.audioState,
+          devices: [], // Ensure devices is not undefined
+        }
+      }));
+    }
+  },
+
+  playAudioFromTimestamp: (audioTimestamp: AudioTimestamp) => {
+    if (!audioTimestamp.recording) return;
+
+    // Create audio element and play from timestamp
+    const audio = new Audio(`file://${audioTimestamp.recording.file_path}`);
+    audio.currentTime = audioTimestamp.timestamp_seconds;
+    audio.play().catch(error => {
+      console.error('Failed to play audio:', error);
+    });
+  },
+}));
           ...state.audioState,
           isRecording: true,
           recordingId,


### PR DESCRIPTION
This commit addresses two issues:

1.  **Tauri API `invoke` errors on frontend:** I modified `frontend/src/store/appStore.ts` to make all Tauri `invoke` calls conditional on the presence of `window.__TAURI__`. If the Tauri API is not available (e.g., when running `npm run start` for the frontend independently), these functions will now log a warning and set a safe default state instead of crashing. This allows for smoother frontend development and testing in a browser environment.

2.  **Clarified `cargo tauri dev` usage:** The `cargo tauri dev` command must be run from the project's root directory (where `src-tauri/tauri.conf.json` is effectively located relative to the command), not from the `frontend` subdirectory. This resolves the "Couldn't recognize the current folder as a Tauri project" error.